### PR TITLE
dxfReader: remove spaces in tab-indented code

### DIFF
--- a/dxfReader.py
+++ b/dxfReader.py
@@ -86,10 +86,10 @@ class StateMachine:
 	def run(self, cargo=None):
 		if not self.startState:
 			raise InitializationError(
-				  "must call .set_start() before .run()")
+				"must call .set_start() before .run()")
 		if not self.endStates:
 			raise InitializationError(
-				  "at least one state must be an end_state")
+				"at least one state must be an end_state")
 		handler = self.startState
 		while 1:
 			(newState, cargo) = handler(cargo)


### PR DESCRIPTION
In this forum thread, [0.18 DXF import problem](https://forum.freecadweb.org/viewtopic.php?f=3&t=39518), we see an error message when trying to use `dxfReader` in FreeCAD 0.18. The error was also previously reported in [import dxf and dwg in ver 18?](https://forum.freecadweb.org/viewtopic.php?f=3&t=32592) In both cases the problem was solved by just re-installing the DXF libraries with the Addon Manager.

However, the error message seems to indicate that the root cause of the issue is that the code mixes tabs with spaces, which is a syntax error in Python 3. This pull request removes the spaces from two lines, so that the entire code is consistently indented with tabs only.

What I find weird is that the users don't report any more issues after updating their versions of these libraries. The libraries that they have still mix tabs and spaces, but they don't see the error any more. It is as if the Python interpreter found the error with a previous version of  `dxfReader.py`, but not with a more recent version.

* Theory 1: when the new  `dxfReader.py` is compiled into Python bytecode (in the directory `__pycache__`), the interpreter optimizes the code, removing the problem entirely.
* Theory 2: FreeCAD uses the newer `dxfReader.py` in a slightly different way, and avoids the functions that cause the problem. The code is still there, but is not triggered at all.

In any case, this pull request is the proper solution for this issue.

There are other instances of mixing tabs and spaces in `dxfLibrary.py`. They all happen inside parentheses, or in continuation lines using a backslash `\`. I think this was done in order to align the code inside the parentheses with the previous line. However, in general this is not a good style because the code only aligns well when the tab width is set to 4 spaces; if the tab width is displayed as 8 spaces, like GitHub does, then it doesn't align the code as the author intended.

This is why it's preferable to be consistent with PEP8 rules, and use only tabs or spaces, for indentation.